### PR TITLE
Add requestType to buildURL.

### DIFF
--- a/addon/adapters/drf.js
+++ b/addon/adapters/drf.js
@@ -47,8 +47,8 @@ export default DS.RESTAdapter.extend({
    * @param {DS.Snapshot} snapshot
    * @return {String} url
    */
-  buildURL: function(type, id, snapshot) {
-    var url = this._super(type, id, snapshot);
+  buildURL: function(type, id, snapshot, requestType) {
+    var url = this._super(type, id, snapshot, requestType);
     if (this.get('addTrailingSlashes')) {
       if (url.charAt(url.length - 1) !== '/') {
         url += '/';

--- a/tests/acceptance/crud-success-test.js
+++ b/tests/acceptance/crud-success-test.js
@@ -41,7 +41,11 @@ module('Acceptance: CRUD Success', {
 
       // Retrieve list of non-paginated records
       this.get('/test-api/posts/', function(request) {
-        return [200, {'Content-Type': 'application/json'}, JSON.stringify(posts)];
+        if (request.queryParams.post_title === 'post title 2') {
+          return [200, {'Content-Type': 'application/json'}, JSON.stringify([posts[1]])];
+        } else {
+          return [200, {'Content-Type': 'application/json'}, JSON.stringify(posts)];
+        }
       });
 
       // Retrieve single record
@@ -100,6 +104,22 @@ test('Retrieve single record', function(assert) {
       assert.ok(post);
       assert.equal(post.get('postTitle'), 'post title 1');
       assert.equal(post.get('body'), 'post body 1');
+    });
+  });
+});
+
+test('Retrieve via query', function(assert) {
+  assert.expect(3);
+
+  return Ember.run(function() {
+
+    return store.find('post', {post_title: 'post title 2'}).then(function(post) {
+
+      assert.ok(post);
+
+      post = post.objectAt(0);
+      assert.equal(post.get('postTitle'), 'post title 2');
+      assert.equal(post.get('body'), 'post body 2');
     });
   });
 });


### PR DESCRIPTION
In canary, this allows for other types of find queries to be handled correctly, e.g. `store.find('person', {name: 'Ben'});`.

Added an acceptance test for this, but it turns out that 2 pagination tests were failing because of changes to the handling of find queries. This patch fixes those, too, so all tests are now passing in canary.

[Ember-data now uses a new buildURL signature](https://github.com/emberjs/data/blob/v1.0.0-beta.17/packages/ember-data/lib/adapters/build-url-mixin.js#L51)
